### PR TITLE
Disable automatic WMS time capability request

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
         // We supply the time domain via map.timeDimensionOptions above; no GetCapabilities needed.
         // If you prefer to auto-fetch times from the server, set requestTimeFromCapabilities:true
         // but be aware of CORS/proxy requirements in some environments.
+        requestTimeFromCapabilities: false,
         cache: 6,                      // small cache when scrubbing the slider
         setDefaultTime: true
       });


### PR DESCRIPTION
## Summary
- disable automatic TimeDimension capability requests to avoid blocked cross-origin calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca10a285c83279564746de96de335