### PR TITLE
Simplify demo to basic WMS layers

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,11 +13,6 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-draw@1.0.4/dist/leaflet.draw.css">
   <script src="https://cdn.jsdelivr.net/npm/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
 
-  <!-- TimeDimension (adds a timeline / controls + WMS time support) -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.min.css">
-  <script src="https://cdn.jsdelivr.net/npm/iso8601-js-period@0.2.1/iso8601.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.min.js"></script>
-
   <style>
     html, body, #map { height: 100%; margin: 0; }
     .toolbar {
@@ -59,20 +54,7 @@
 
     const map = L.map('map', {
       center: [20, 0],
-      zoom: 3,
-      // Enable TimeDimension on the map
-      timeDimension: true,
-      timeDimensionControl: true,
-      timeDimensionOptions: {
-        // Reasonable daily range; adjust as desired.
-        timeInterval: "2013-01-01/" + todayISO,  // VIIRS SNPP starts ~2012; MODIS since 2000s
-        period: "P1D"                            // daily step
-      },
-      timeDimensionControlOptions: {
-        position: 'bottomleft',
-        autoPlay: false,
-        timeSliderDragUpdate: true
-      }
+      zoom: 3
     });
 
     // Attribution (GIBS + Leaflet)
@@ -112,7 +94,7 @@
       a.remove();
     });
 
-    // --- NASA GIBS WMS (time-enabled) ---------------------------------------
+    // --- NASA GIBS WMS (basic imagery) --------------------------------------
     // WMS endpoint in EPSG:3857 (Web Mercator); no key required.
     // Docs: https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi?
     const GIBS_WMS = 'https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi?';
@@ -125,60 +107,50 @@
       version: '1.3.0'
     }).addTo(map);
 
-    let currentTimedLayer = null;
+    let currentImageryLayer = null;
 
-    function buildTimedLayer(layerId) {
-      const baseWms = L.tileLayer.wms(GIBS_WMS, {
+    function buildImageryLayer(layerId, dateISO) {
+      const timeParam = dateISO || todayISO;
+      return L.tileLayer.wms(GIBS_WMS, {
         layers: layerId,
         format: 'image/jpeg',   // faster for full-color imagery
         transparent: false,
-        version: '1.3.0'
+        version: '1.3.0',
+        time: timeParam,
+        crossOrigin: 'anonymous'
       });
-
-      // Tie the WMS layer to the map's TimeDimension; it will set the `time` param automatically.
-      const tdLayer = L.timeDimension.layer.wms(baseWms, {
-        // We supply the time domain via map.timeDimensionOptions above; no GetCapabilities needed.
-        // If you prefer to auto-fetch times from the server, set requestTimeFromCapabilities:true
-        // but be aware of CORS/proxy requirements in some environments.
-        requestTimeFromCapabilities: false,
-        cache: 6,                      // small cache when scrubbing the slider
-        setDefaultTime: true
-      });
-      return tdLayer;
     }
 
-    function setImageryLayer(layerId) {
-      if (currentTimedLayer) {
-        map.removeLayer(currentTimedLayer);
+    function setImageryLayer(layerId, dateISO) {
+      if (currentImageryLayer) {
+        map.removeLayer(currentImageryLayer);
       }
-      currentTimedLayer = buildTimedLayer(layerId);
-      currentTimedLayer.addTo(map);
+      currentImageryLayer = buildImageryLayer(layerId, dateISO);
+      currentImageryLayer.addTo(map);
     }
 
-    // UI: Layer switcher
-    const layerSelect = document.getElementById('layer');
-    layerSelect.addEventListener('change', (e) => setImageryLayer(e.target.value));
-
-    // UI: Date picker -> sync with TimeDimension
+    // UI: Date picker -> update TIME parameter on WMS layer
     const dateInput = document.getElementById('date');
     dateInput.value = todayISO;
     dateInput.min = '2000-01-01';
     dateInput.max = todayISO;
 
     dateInput.addEventListener('change', (e) => {
-      const d = e.target.value;
-      if (!d) return;
-      // Set map time (ms since epoch); TimeDimension will trigger WMS with `time=YYYY-MM-DD`
-      const t = Date.parse(d + 'T00:00:00Z');
-      if (!isNaN(t)) {
-        map.timeDimension.setCurrentTime(t);
-      }
+      const d = e.target.value || todayISO;
+      if (!currentImageryLayer) return;
+      currentImageryLayer.setParams({ time: d });
     });
 
+    const layerSelect = document.getElementById('layer');
+
     // Initialize first layer
-    setImageryLayer(layerSelect.value);
-    // Ensure initial date is applied
-    map.timeDimension.setCurrentTime(Date.parse(dateInput.value + 'T00:00:00Z'));
+    setImageryLayer(layerSelect.value, dateInput.value);
+
+    // Keep imagery in sync when switching between layers
+    layerSelect.addEventListener('change', (e) => {
+      const dateISO = dateInput.value || todayISO;
+      setImageryLayer(e.target.value, dateISO);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove TimeDimension dependencies and configuration from the demo viewer
- load GIBS imagery with standard Leaflet WMS layers and update the TIME parameter directly
- keep layer switching and date selection working without the time slider

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca382b3448327b82e76fce9f71dbe