### PR TITLE
Move map controls and update defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,24 @@
-# openeo
+# Open EO Viewer
 
-This repository collects notes and helper snippets for working with NASA's
-Global Imagery Browse Services (GIBS) layers in client applications such as
-Leaflet.
+Open EO Viewer is a lightweight Leaflet application for exploring NASA's Global Imagery Browse Services (GIBS) layers. It lets you switch between common true-color products, pick a date, and sketch areas of interest directly on the map. Drawn shapes can be exported to GeoJSON for further analysis or sharing with other tools.
 
-## Debugging CORB warnings with GIBS imagery
+## Features
 
-Chrome's Cross-Origin Read Blocking (CORB) warnings can appear when loading
-GIBS VIIRS layers if the imagery date does not exist for the selected
-platform. The server responds with an XML `ServiceException`, but because the
-client expects image bytes the browser logs a CORB warning even though the
-request succeeded.
+- **Leaflet + GIBS integration** – browse daily NASA imagery without needing an API key.
+- **Layer switching** – toggle between VIIRS and MODIS true-color layers with a single dropdown.
+- **Date selection** – start from the latest NOAA-20 true-color image (2025-06-06) or choose any other available day.
+- **Drawing tools** – capture polygons or rectangles on top of the imagery and export them as GeoJSON.
 
-### Why it happens
+## Getting started
 
-* **Wrong platform/date combination** – for example, requesting
-  `VIIRS_NOAA20_CorrectedReflectance_TrueColor` tiles for 2013 returns a
-  `ServiceException` because NOAA-20 only began producing data in late 2017.
-* **Supported time formats** – daily products accept `TIME=YYYY-MM-DD` (ISO
-  timestamps such as `YYYY-MM-DDTHH:MM:SSZ` are also accepted, but the date must
-  exist for the layer).
-* **Meaning of CORB** – CORB blocks cross-origin HTML/XML/JSON bodies from
-  being read when an image response was expected; it does not mean the network
-  request failed.
+1. Open `index.html` in a browser (or serve the repository with your favorite static file server).
+2. Use the layer and date controls in the toolbar to update the map imagery.
+3. Activate the drawing controls in the lower-left corner to sketch features and export them via the **Export GeoJSON** button.
 
-### Fixes
+## Contributing
 
-* Request a valid date for the selected platform, e.g.
-  `TIME=2018-01-02` for NOAA-20 VIIRS corrected reflectance.
-* Use the Suomi-NPP VIIRS layer (`VIIRS_SNPP_CorrectedReflectance_TrueColor`)
-  when imagery prior to late 2017 is required (data coverage starts on
-  2015-11-24).
+This project is intentionally simple and we welcome ideas that make it more useful. If you build a new capability—such as additional imagery layers, new export formats, or enhanced map interactions—please open a pull request so others can benefit as well. Bug fixes, documentation improvements, and other suggestions are also appreciated!
 
-### Leaflet example
+## License
 
-```html
-<div id="map" style="height: 70vh;"></div>
-<label>
-  Date:
-  <input id="date" type="date" value="2018-01-02" min="2017-11-19" max="2025-10-01">
-</label>
-
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script>
-  const map = L.map('map').setView([20, 0], 2);
-
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 9,
-    attribution: '&copy; OpenStreetMap contributors'
-  }).addTo(map);
-
-  const gibsEndpoint = 'https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi';
-
-  const viirsLayer = L.tileLayer.wms(gibsEndpoint, {
-    layers: 'VIIRS_NOAA20_CorrectedReflectance_TrueColor',
-    version: '1.3.0',
-    format: 'image/jpeg',
-    transparent: false,
-    time: '2018-01-02',
-    tileSize: 256,
-    crossOrigin: 'anonymous'
-  }).addTo(map);
-
-  document.getElementById('date').addEventListener('change', (event) => {
-    viirsLayer.setParams({ TIME: event.target.value });
-  });
-
-  // Switch to Suomi-NPP for pre-2017 dates
-  // viirsLayer.setParams({ layers: 'VIIRS_SNPP_CorrectedReflectance_TrueColor', TIME: '2016-01-02' });
-</script>
-```
-
-This example demonstrates how to update the `TIME` parameter in response to a
-date-picker control. Use `format: 'image/png'` with `transparent: true` when
-overlaying the imagery on top of another basemap.
+This repository is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <select id="layer">
       <!-- GIBS layer identifiers (True Color) -->
       <option value="VIIRS_SNPP_CorrectedReflectance_TrueColor">VIIRS SNPP True Color</option>
-      <option value="VIIRS_NOAA20_CorrectedReflectance_TrueColor">VIIRS NOAA‑20 True Color</option>
+      <option value="VIIRS_NOAA20_CorrectedReflectance_TrueColor" selected>VIIRS NOAA‑20 True Color</option>
       <option value="MODIS_Terra_CorrectedReflectance_TrueColor">MODIS Terra True Color</option>
     </select>
 
@@ -51,11 +51,15 @@
   <script>
     // --- Map setup -----------------------------------------------------------
     const todayISO = new Date().toISOString().slice(0,10);
+    const defaultDateISO = '2025-06-06';
+    const initialLayerId = 'VIIRS_NOAA20_CorrectedReflectance_TrueColor';
 
     const map = L.map('map', {
       center: [20, 0],
       zoom: 3
     });
+
+    map.zoomControl.setPosition('bottomleft');
 
     // Attribution (GIBS + Leaflet)
     map.attributionControl.setPrefix(false);
@@ -65,6 +69,7 @@
     // --- Drawing layer + controls -------------------------------------------
     const drawnItems = new L.FeatureGroup().addTo(map);
     const drawControl = new L.Control.Draw({
+      position: 'bottomleft',
       edit: { featureGroup: drawnItems },
       draw: {
         polygon: { allowIntersection: false, showArea: true },
@@ -131,9 +136,10 @@
 
     // UI: Date picker -> update TIME parameter on WMS layer
     const dateInput = document.getElementById('date');
-    dateInput.value = todayISO;
+    dateInput.value = defaultDateISO;
     dateInput.min = '2000-01-01';
-    dateInput.max = todayISO;
+    const latestSelectableDate = todayISO < defaultDateISO ? defaultDateISO : todayISO;
+    dateInput.max = latestSelectableDate;
 
     dateInput.addEventListener('change', (e) => {
       const d = e.target.value || todayISO;
@@ -142,6 +148,7 @@
     });
 
     const layerSelect = document.getElementById('layer');
+    layerSelect.value = initialLayerId;
 
     // Initialize first layer
     setImageryLayer(layerSelect.value, dateInput.value);


### PR DESCRIPTION
## Summary
- reposition the Leaflet zoom and drawing controls to the bottom-left to avoid overlapping the toolbar
- default the viewer to the NOAA-20 true color layer with imagery dated 2025-06-06 and adjust date bounds accordingly
- rewrite the README to describe the viewer and invite feature contributions via pull requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca6ab01b08327bef5c29ab26f55c4