### PR TITLE
Add imagery status indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,6 +346,41 @@
       background: rgba(59, 130, 246, 0.1);
     }
 
+    .layer-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 8px;
+      font-size: 12px;
+      color: var(--text-muted);
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid var(--input-border);
+      background: var(--input-bg);
+    }
+
+    .status-dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: var(--text-muted);
+    }
+
+    .status-dot.loading {
+      background: #f59e0b;
+      box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.15);
+    }
+
+    .status-dot.ready {
+      background: #22c55e;
+      box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
+    }
+
+    .status-dot.error {
+      background: #ef4444;
+      box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.15);
+    }
+
     .storm-status {
       font-size: 12px;
       color: var(--text-muted);
@@ -919,6 +954,10 @@
           </select>
         </div>
         <div class="layer-info" id="layer-info">Select a layer to see its description.</div>
+        <div class="layer-status" id="layer-status">
+          <span class="status-dot loading"></span>
+          <span>Waiting for imagery selection…</span>
+        </div>
       </div>
 
       <!-- Date Selection -->
@@ -1348,15 +1387,30 @@
       }
       const imageryDate = dateISO || todayISO;
       const nextLayer = buildImageryLayer(layerId, imageryDate);
+      setImageryStatus('loading', `Loading ${layerId} for ${imageryDate}…`);
+
+      nextLayer.on('loading', () => {
+        const loadDate = nextLayer.wmsParams.time || imageryDate;
+        setImageryStatus('loading', `Loading ${layerId} for ${loadDate}…`);
+      });
+      nextLayer.on('load', () => {
+        const finalDate = nextLayer.wmsParams.time || imageryDate;
+        setImageryStatus('ready', `Showing ${layerId} • ${finalDate}`);
+      });
 
       if (allowFallback) {
         nextLayer.once('tileerror', () => {
           const fallbackDate = shiftDate(imageryDate, -1);
           if (fallbackDate >= dateInput.min) {
+            setImageryStatus('error', `Imagery unavailable for ${imageryDate}; trying ${fallbackDate}.`);
             console.warn(`Imagery unavailable for ${imageryDate}; falling back to ${fallbackDate}`);
             setDateSafely(fallbackDate);
             setImageryLayer(layerId, fallbackDate, { allowFallback: false });
           }
+        });
+      } else {
+        nextLayer.once('tileerror', () => {
+          setImageryStatus('error', `Imagery unavailable for ${imageryDate}.`);
         });
       }
 
@@ -1376,6 +1430,7 @@
       dateInput.value = formatted;
       if (currentImageryLayer) {
         currentImageryLayer.setParams({ time: formatted });
+        setImageryStatus('loading', `Loading ${layerSelect.value} for ${formatted}…`);
       }
     }
 
@@ -1415,6 +1470,17 @@
       'VIIRS_SNPP_CorrectedReflectance_BandsM3-M11-I2': 'VIIRS SNPP Shortwave IR: Useful for fire and land analysis.',
       'VIIRS_SNPP_CorrectedReflectance_BandsI1-I2-I3': 'VIIRS SNPP Land/Vegetation: Visible and near-infrared bands.'
     };
+
+    const layerStatus = document.getElementById('layer-status');
+    const layerStatusDot = layerStatus.querySelector('.status-dot');
+    const layerStatusText = layerStatus.querySelector('span:last-child');
+
+    function setImageryStatus(state, message) {
+      // Status widget was inspired by MSS26 students requesting clearer feedback on their mapping contributions.
+      layerStatusDot.classList.remove('loading', 'ready', 'error');
+      layerStatusDot.classList.add(state);
+      layerStatusText.textContent = message;
+    }
 
     function updateLayerInfo(layerId) {
       const info = layerDescriptions[layerId] || 'No description available.';


### PR DESCRIPTION
## Summary
- add a sidebar imagery status badge that communicates loading, success, and error states
- update layer loading logic to surface fallback errors and provide immediate feedback on date changes
- document student-inspired feedback directly in the status helper for future contributors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f071487908327a0af97efdf8db492)